### PR TITLE
Endpoint and App ID URI are different

### DIFF
--- a/src/TinyBlazorAdmin/Data/AzFuncAuthorizationMessageHandler.cs
+++ b/src/TinyBlazorAdmin/Data/AzFuncAuthorizationMessageHandler.cs
@@ -11,6 +11,8 @@ namespace TinyBlazorAdmin.Data
     {
         public string Endpoint { get; set; }
 
+        public string AppIdUri { get; set; }
+
         /// <summary>
         /// Creates a new instance of the <see cref="AzFuncAuthorizationMessageHandler"/>
         /// class.
@@ -27,7 +29,7 @@ namespace TinyBlazorAdmin.Data
             Endpoint = section.GetValue<string>(nameof(Endpoint));
             ConfigureHandler(
                 new[] { Endpoint },
-                new[] { string.Concat(Endpoint, "user_impersonation") }
+                new[] { string.Concat(AppIdUri, "user_impersonation") }
             );
         }
     }

--- a/src/TinyBlazorAdmin/Program.cs
+++ b/src/TinyBlazorAdmin/Program.cs
@@ -22,13 +22,18 @@ namespace TinyBlazorAdmin
                     .GetSection(nameof(UrlShortenerSecuredService))
                     .GetValue<string>(nameof(AzFuncAuthorizationMessageHandler.Endpoint));
 
+            static string functionAppIdUri(WebAssemblyHostBuilder builder) =>
+                builder.Configuration
+                    .GetSection(nameof(UrlShortenerSecuredService))
+                    .GetValue<string>(nameof(AzFuncAuthorizationMessageHandler.AppIdUri));
+
             // sets up AAD + user_impersonation to access functions.
             builder.Services.AddMsalAuthentication(options =>
             {
                 options.ProviderOptions
                 .DefaultAccessTokenScopes.Add("user.read");
                 options.ProviderOptions
-                .AdditionalScopesToConsent.Add($"{functionEndpoint(builder)}user_impersonation");
+                .AdditionalScopesToConsent.Add($"{functionAppIdUri(builder)}user_impersonation");
                 builder.Configuration.Bind("AzureAd", options.ProviderOptions.Authentication);
             });
 

--- a/src/TinyBlazorAdmin/wwwroot/appsettings.json
+++ b/src/TinyBlazorAdmin/wwwroot/appsettings.json
@@ -5,7 +5,8 @@
     "ValidateAuthority": true
   },
   "UrlShortenerSecuredService": {
-    "Endpoint": "https://azshorterdevrtm3e.azurewebsites.net/"
+    "Endpoint": "https://azshorterdevrtm3e.azurewebsites.net/",
+    "AppIdUri": "api://00000000-0000-0000-0000-000000000000/"
   },
   "DetailedErrors":true
 }


### PR DESCRIPTION
Per a change in Azure AD in October 2021, "*.azurewebsites.net" urls cannot be set as the App ID URI for an AD app. Because of this, the App ID URI and the Endpoint can differ as mentioned in https://github.com/FBoucher/AzUrlShortener/issues/306

More info about the AD change: https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-breaking-changes#appid-uri-in-single-tenant-applications-will-require-use-of-default-scheme-or-verified-domains