### PR TITLE
Fix types passed to CreateLogger in API Functions

### DIFF
--- a/src/api/function/UrlArchive.cs
+++ b/src/api/function/UrlArchive.cs
@@ -50,7 +50,7 @@ namespace Cloud5mins.Function
 
         public UrlArchive(ILoggerFactory loggerFactory, AdminApiSettings settings)
         {
-            _logger = loggerFactory.CreateLogger<UrlList>();
+            _logger = loggerFactory.CreateLogger<UrlArchive>();
             _adminApiSettings = settings;
         }
 

--- a/src/api/function/UrlShortener.cs
+++ b/src/api/function/UrlShortener.cs
@@ -43,7 +43,7 @@ namespace Cloud5mins.Function
 
         public UrlShortener(ILoggerFactory loggerFactory, AdminApiSettings settings)
         {
-            _logger = loggerFactory.CreateLogger<UrlList>();
+            _logger = loggerFactory.CreateLogger<UrlShortener>();
             _adminApiSettings = settings;
         }
 

--- a/src/api/function/UrlUpdate.cs
+++ b/src/api/function/UrlUpdate.cs
@@ -56,7 +56,7 @@ namespace Cloud5mins.Function
 
         public UrlUpdate(ILoggerFactory loggerFactory, AdminApiSettings settings)
         {
-            _logger = loggerFactory.CreateLogger<UrlList>();
+            _logger = loggerFactory.CreateLogger<UrlUpdate>();
             _adminApiSettings = settings;
         }
 


### PR DESCRIPTION
Seems like these were just typos and should match the parent class name.